### PR TITLE
Refs #290022 - Include (missing) bar for current year (or range).

### DIFF
--- a/searchlib/lib/utils.js
+++ b/searchlib/lib/utils.js
@@ -84,7 +84,7 @@ export function makeRange(options) {
   // TODO: check range increment (2010-2015, 2016-2020)
   for (
     let i = normalRange[0];
-    i < normalRange[normalRange.length - 1];
+    i <= normalRange[normalRange.length - 1];
     i += step
   ) {
     res.push({ from: i, to: i + step });


### PR DESCRIPTION
As result, histogram is correct when selecting Last year, Last 5 years, etc.